### PR TITLE
Update migration

### DIFF
--- a/packages/2fa.md
+++ b/packages/2fa.md
@@ -73,7 +73,7 @@ class AddTwoFaColumnsToLitUsersTable extends Migration
     {
         Schema::table('lit_users', function (Blueprint $table) {
             $table->boolean('two_fa_enabled');
-            $table->string('two_fa_secret');
+            $table->text('two_fa_secret');
         });
     }
 


### PR DESCRIPTION
The `two_factor_secret` can be more than 255 chars length.

Also, [`laravel/fortify`](https://github.com/laravel/fortify/blob/1.x/database/migrations/2014_10_12_200000_add_two_factor_columns_to_users_table.php#L18) uses `text` instead of `string`.

Relates litstack/2fa#3